### PR TITLE
Mutraction without the leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
 node_modules
-Quarks/out
-Quarks/out2
-Quarks/dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+Quarks/out
+Quarks/out2
+Quarks/dist

--- a/Quarks/.babelrc
+++ b/Quarks/.babelrc
@@ -1,0 +1,3 @@
+{
+    "plugins": ["@babel/plugin-syntax-jsx", "mutraction-dom/compile-jsx"]
+}

--- a/Quarks/out/index.jsx
+++ b/Quarks/out/index.jsx
@@ -3,6 +3,7 @@
 //remove the defaultTypes
 //inventory/generators back to arrays
 //tab doesn't highlight correctly.
+//able to downgrade generators?
 //save/load
 //save/load object
 //inventory {f.name, amount}

--- a/Quarks/out2/index.js
+++ b/Quarks/out2/index.js
@@ -5,6 +5,7 @@ import { element as _mu_element, child as _mu_child, choose as _mu_choose } from
 //remove the defaultTypes
 //inventory/generators back to arrays
 //tab doesn't highlight correctly.
+//able to downgrade generators?
 //save/load
 //save/load object
 //inventory {f.name, amount}

--- a/Quarks/package-lock.json
+++ b/Quarks/package-lock.json
@@ -2595,9 +2595,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/mutraction-dom": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/mutraction-dom/-/mutraction-dom-0.21.5.tgz",
-      "integrity": "sha512-wrwV1Asg8JwNfm1VnFYmh591jcIrAhhE3rFvsCOtCRynyyHWpNZ2R65FB5Wd3UoCFJdHEVuA6vRAOs1TvjU4lA==",
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/mutraction-dom/-/mutraction-dom-0.22.4.tgz",
+      "integrity": "sha512-UcxkC5VoG4QqQfHKaUgzhnJgR15sAbe2YZFsvDmrzLhfKXTP2BVmTBMGypvhn7/QAtfvai6poszbk/fZxAQZwg==",
       "dependencies": {
         "@babel/cli": "^7.22.10",
         "@babel/core": "^7.22.10",


### PR DESCRIPTION
This is basically just an update to the included mutraction version.  Four distinct leaks were fixed.  There's still a slow "leak" that tracks history.  This seems < 20mb/hour.  It can be turned off, but this PR doesn't change any of the source code.  The build outputs are different because they include the updated mutraction source.

You'll have to `npm install` to get the new dependencies if you want to repeat the build.